### PR TITLE
require RMagick only when needed

### DIFF
--- a/lib/paleta/palette.rb
+++ b/lib/paleta/palette.rb
@@ -4,7 +4,7 @@ module Paleta
   
   module MagickDependent
     def self.included(klass)
-      require 'RMagick'
+      require 'RMagick' unless defined?(Magick)
       klass.extend(ClassMethods)
     rescue LoadError
       puts "You must install RMagick to use Palette.generate(:from => :image, ...)"


### PR DESCRIPTION
If my project already added the rmagick gem a lot of warnings are thrown because it was already required.
