### PR TITLE
Round floats to avoid problems

### DIFF
--- a/lib/paleta/color.rb
+++ b/lib/paleta/color.rb
@@ -277,10 +277,10 @@ module Paleta
         end
       end
 
-      @hue = h * 60
+      @hue = (h * 60.0).round(8)
       @hue += 360 if @hue < 0
-      @saturation = s * 100
-      @lightness = l * 100
+      @saturation = (s * 100.0).round(8)
+      @lightness = (l * 100.0).round(8)
     end
 
     def update_rgb


### PR DESCRIPTION
Hi there,

I ran into an issue this past weekend with floating point imprecision when creating a new color in Paleta. To reproduce you can try this:

`color = Paleta::Color.new(:hex, "FFDE38")`

You'll notice that the saturation ends up being something like `100.00000000003` which fails the range validation of `0..100`. There are a couple of potential fixes: use a `BigDecimal` for greater accuracy, or round the floats to avoid the imprecision. I opted for rounding and picked eight decimal places somewhat arbitrarily.

Let me know what you think or if you have other ideas.