### PR TITLE
alert missing rmagick on method call, rather than on load

### DIFF
--- a/lib/paleta.rb
+++ b/lib/paleta.rb
@@ -3,4 +3,13 @@ require 'paleta/color'
 require 'paleta/palette'
 
 module Paleta
+  @rmagick_available = begin
+    require "rmagick"
+  rescue LoadError
+    false
+  end
+
+  def self.rmagick_available?
+    @rmagick_available
+  end
 end

--- a/lib/paleta.rb
+++ b/lib/paleta.rb
@@ -3,6 +3,8 @@ require 'paleta/color'
 require 'paleta/palette'
 
 module Paleta
+  class MissingDependencyError < StandardError; end
+
   @rmagick_available = begin
     require "rmagick"
   rescue LoadError

--- a/lib/paleta/palette.rb
+++ b/lib/paleta/palette.rb
@@ -1,38 +1,10 @@
 require 'paleta/core_ext/math'
 
 module Paleta
-  module MagickDependent
-    def self.included(klass)
-      require 'RMagick' unless defined?(Magick)
-      klass.extend(ClassMethods)
-    rescue LoadError
-      puts "You must install RMagick to use Palette.generate(:from => :image, ...)"
-    end
-
-    module ClassMethods
-      def generate_from_image(path, size = 5)
-        include Magick
-        begin
-          image = Magick::ImageList.new(path)
-
-          # quantize image to the nearest power of 2 greater the desired palette size
-          quantized_image = image.quantize((Math.sqrt(size).ceil ** 2), Magick::RGBColorspace)
-          colors = quantized_image.color_histogram.sort { |a, b| b[1] <=> a[1] }[0..(size - 1)].map do |color|
-            Paleta::Color.new(color[0].red / 256, color[0].green / 256, color[0].blue / 256)
-          end
-          return Paleta::Palette.new(colors)
-        rescue Magick::ImageMagickError
-          raise "Invalid image at " << path
-        end
-      end
-    end
-  end
-
   # Represents a palette, a collection of {Color}s
   class Palette
     include Math
     include Enumerable
-    include MagickDependent
 
     attr_accessor :colors
 
@@ -236,6 +208,25 @@ module Paleta
     end
 
     private
+
+    def self.generate_from_image(path, size = 5)
+      unless Paleta.rmagick_available?
+        return puts "You must install RMagick to use Palette.generate(:from => :image, ...)"
+      end
+
+      begin
+        image = Magick::ImageList.new(path)
+
+        # quantize image to the nearest power of 2 greater the desired palette size
+        quantized_image = image.quantize((Math.sqrt(size).ceil ** 2), Magick::RGBColorspace)
+        colors = quantized_image.color_histogram.sort { |a, b| b[1] <=> a[1] }[0..(size - 1)].map do |color|
+          Paleta::Color.new(color[0].red / 256, color[0].green / 256, color[0].blue / 256)
+        end
+        return Paleta::Palette.new(colors)
+      rescue Magick::ImageMagickError
+        raise "Invalid image at " << path
+      end
+    end
 
     def self.generate_analogous_from_color(color, size)
       raise(ArgumentError, "Passed argument is not a Color") unless color.is_a?(Color)

--- a/lib/paleta/palette.rb
+++ b/lib/paleta/palette.rb
@@ -211,7 +211,7 @@ module Paleta
 
     def self.generate_from_image(path, size = 5)
       unless Paleta.rmagick_available?
-        return puts "You must install RMagick to use Palette.generate(:from => :image, ...)"
+        raise Paleta::MissingDependencyError, "You must install RMagick to use Palette.generate(:from => :image, ...)"
       end
 
       begin

--- a/spec/models/palette_spec.rb
+++ b/spec/models/palette_spec.rb
@@ -231,6 +231,17 @@ describe Paleta::Palette do
     palette.size.should == size
   end
 
+  it "should raise when generating a Palette from an image without RMagick" do
+    # stub Paleta.rmagick_available? to return false
+    allow(Paleta).to receive(:rmagick_available?).and_return(false)
+
+    path = File.join(File.dirname(__FILE__), '..', 'images/test.jpg')
+    size = 5
+    expect do
+      Paleta::Palette.generate(:from => :image, :image => path, :size => size)
+    end.to raise_error(Paleta::MissingDependencyError)
+  end
+
   it "should raise an error when generating a Palette from an invalid image" do
     expect{ Paleta::Palette.generate(:from => :image, :image => "/no/image.here") }.to raise_error(RuntimeError)
   end


### PR DESCRIPTION
Following @nadavshatz advice on improving the rmagick dependency warning.

This actually solves #9 even though I closed that issue early.
